### PR TITLE
fix!: refactor writePackageJson to not require path

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,7 +217,7 @@ async function main (input, _opts = {}) {
   })()
 
   opts = options.values()
-  return write(path.resolve(opts.cwd, 'package.json'), opts, await format(opts, pkg), { log })
+  return write(opts, await format(opts, pkg), { log })
 }
 
 module.exports.options = initOpts().options
@@ -302,6 +302,8 @@ async function format (opts, pkg = {}) {
     pkg.peerDependencies = {}
 
     await Promise.all(opts.peerDependencies.map(async (name) => {
+      // @TODO we should align peer deps with the associated
+      // devDep or prodDep semver range
       const spec = await npm.normalizePackageName(name)
       let ver
       switch (spec.type) {
@@ -320,7 +322,8 @@ async function format (opts, pkg = {}) {
 
 module.exports.write = write
 // TODO: look at https://npm.im/json-file-plus for writing
-async function write (pkgPath, opts, pkg, { log } = {}) {
+async function write (opts, pkg, { log } = {}) {
+  const pkgPath = path.resolve(opts.cwd, 'package.json')
   // Write package json
   log.info(`Writing package.json\n${pkgPath}`)
   await fs.outputJSON(pkgPath, pkg, {

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ function initOpts () {
         prompt: {
           message: 'Repository:',
           default: (promptInput, allInput) => {
-            return allInput.repository || git.remote({ cwd: allInput.cwd })
+            return allInput.repository
           }
         }
       },
@@ -251,6 +251,18 @@ async function readPackageJson (options, { log } = {}) {
     author = `${pkg.author.name}${pkg.author.email ? ` <${pkg.author.email}>` : ''}`
   }
 
+  let repo
+  if (!pkg || !pkg.repository) {
+    const gitRemote = await git.remote({ cwd: opts.cwd })
+    if (gitRemote) {
+      repo = gitRemote
+    }
+  } else if (pkg && typeof pkg.repository === 'string') {
+    repo = pkg.repository
+  } else if (pkg && typeof pkg.repository !== 'undefined' && pkg.repository.url) {
+    repo = pkg.repository.url
+  }
+
   // Set defaults from the package.json
   options.defaults({
     version: pkg.version,
@@ -258,7 +270,7 @@ async function readPackageJson (options, { log } = {}) {
     type: pkg.type,
     author: author,
     description: pkg.description,
-    repository: pkg.repository,
+    repository: repo,
     keywords: pkg.keywords,
     scripts: pkg.scripts,
     license: pkg.license

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function initOpts () {
         prompt: {
           message: 'Author:',
           default: (promptInput, allInput) => {
-            return allInput.author || git.author({ cwd: allInput.cwd })
+            return allInput.author
           }
         }
       },
@@ -239,12 +239,24 @@ async function readPackageJson (options, { log } = {}) {
     // ignore if missing or unreadable
   }
 
+  let author
+  if (!pkg || !pkg.author) {
+    const gitAuthor = await git.author({ cwd: opts.cwd })
+    if (gitAuthor) {
+      author = gitAuthor
+    }
+  } else if (pkg && typeof pkg.author === 'string') {
+    author = pkg.author
+  } else if (pkg && typeof pkg.author !== 'undefined') {
+    author = `${pkg.author.name}${pkg.author.email ? ` <${pkg.author.email}>` : ''}`
+  }
+
   // Set defaults from the package.json
   options.defaults({
     version: pkg.version,
     name: pkg.name,
     type: pkg.type,
-    author: pkg.author,
+    author: author,
     description: pkg.description,
     repository: pkg.repository,
     keywords: pkg.keywords,


### PR DESCRIPTION
Simplify the signature of `writePackageJson` since we already pass `opts` we have `opts.cwd` and do not need consumers to construct it.

cc @boneskull