### PR TITLE
fix(test): added npm init parity test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,10 @@ jobs:
         node-version: ${{ fromJson(needs.setup.outputs.nodes) }}
     steps:
     - uses: actions/checkout@v4
+    - name: Setup git user
+      run: |
+          git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+          git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:

--- a/index.js
+++ b/index.js
@@ -298,10 +298,8 @@ async function format (opts, pkg = {}) {
   pkg.main = opts.main
   pkg.type = opts.type || 'commonjs'
 
-  if (opts.keywords && opts.keywords.length) {
-    // TODO: extra parsing going on here due to wesleytodd/opta#1
-    pkg.keywords = uniquify([...(pkg.keywords || []), ...parseList(opts.keywords)])
-  }
+  // TODO: extra parsing going on here due to wesleytodd/opta#1
+  pkg.keywords = uniquify([...(pkg.keywords || []), ...parseList(opts.keywords || [])])
 
   // Scripts
   if (Object.keys(opts.scripts).length) {


### PR DESCRIPTION
Added a test to check `npm init -y` parity.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
