### PR TITLE
fix: main should default to existing field when present

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,6 +271,7 @@ async function readPackageJson (options, { log } = {}) {
     version: pkg.version,
     name: pkg.name,
     type: pkg.type,
+    main: pkg.main,
     author,
     description: pkg.description,
     repository: repo,


### PR DESCRIPTION
When `main` exists in a `package.json` use it as the default when prompting.
